### PR TITLE
change order to ZYX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-orientation-vector",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "type": "module",
   "main": "./dist/ov.umd.js",
   "module": "./dist/ov.es.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,6 +169,6 @@ export class OrientationVector {
   }
 
   toEuler (dest: Euler) {
-    return dest.setFromQuaternion(this.toQuaternion(quatA))
+    return dest.setFromQuaternion(this.toQuaternion(quatA), 'ZYX');
   }
 }


### PR DESCRIPTION
When converting from Orientation Vector to Euler Angles, Viam uses ZYX order, but the order for THREE.js is XYZ if not specified. This change specifies the order as ZYX