### PR TITLE
Fix orientation.viam.dev axes labels for the orientation vector

### DIFF
--- a/playground/main.ts
+++ b/playground/main.ts
@@ -97,7 +97,7 @@ pane.addBinding(options, 'units', {
 pane.addBlade({ view: 'separator' })
 inputs.push(
   pane.addBinding(rotations, 'ov', {
-    label: 'orientation vector (th / xyz)'
+    label: 'orientation vector (xyz / th)'
   }).on('change', e => update('ov', e))
 )
 pane.addBlade({ view: 'separator' })


### PR DESCRIPTION
changing `orientation vector (th / xyz)` to `orientation vector (xyz / th)`
In the video below we show how the value we change visually corresponds to `th` but is labeled as `z`
![orientation](https://github.com/viamrobotics/three/assets/46872531/f3dfee21-1439-4f9b-b9c4-cad4ecbd4710)
