### PR TITLE
Add types to package.json exports for bundler resolution mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/three",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/three",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@0b5vr/tweakpane-plugin-rotation": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/three",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -10,6 +10,7 @@
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/ov.js"
     }
   },


### PR DESCRIPTION
Newer TS resolution modes (`nodenext`, `bundler`) require types to be exported from `exports` rather than the top-level `types` field